### PR TITLE
modify path in proto.mk to fix jeremyje/coretemp-exporter#90

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,7 +83,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       with:
         generate_release_notes: true
-        draft: false
+        draft: true
         prerelease: false
         files: |
           LICENSE

--- a/proto.mk
+++ b/proto.mk
@@ -163,8 +163,8 @@ third_party/grpc_gateway/include/protoc-gen-openapiv2/LICENSE.txt: build/archive
 	(cd $(TOOLCHAIN_DIR)/grpc-gateway-temp/; unzip -q -o grpc-gateway.zip)
 	cp -rf $(TOOLCHAIN_DIR)/grpc-gateway-temp/grpc-gateway-main/protoc-gen-openapiv2/options/*.proto \
 		$(THIRDPARTY_DIR)/grpc_gateway/include/protoc-gen-openapiv2/options/
-	cp -f $(TOOLCHAIN_DIR)/grpc-gateway-temp/grpc-gateway-main/LICENSE.txt \
-		$(THIRDPARTY_DIR)/grpc_gateway/include/protoc-gen-openapiv2/LICENSE.txt
+	cp -f $(TOOLCHAIN_DIR)/grpc-gateway-temp/grpc-gateway-main/LICENSE \
+		$(THIRDPARTY_DIR)/grpc_gateway/include/protoc-gen-openapiv2/LICENSE
 	$(FX_FIND) $(THIRDPARTY_DIR)/grpc_gateway/include/protoc-gen-openapiv2/ -type f -name '*BUILD.bazel' -exec rm {} +
 	rm -rf $(TOOLCHAIN_DIR)/grpc-gateway-temp
 	touch $@


### PR DESCRIPTION
Hi @jeremyje ,
This pull request addresses the jeremyje/coretemp-exporter#90, where the Makefile paths were not updating correctly with changes to dependencies. I have modified the Makefile to ensure that the paths are updated appropriately.

Applying this change, the build for all targets finished successfully. I have attached the log here.
[build_2024-02-20_01-11-00.log](https://github.com/jeremyje/coretemp-exporter/files/14334602/build_2024-02-20_01-11-00.log)

If there are any problems, please feel free to correct them.